### PR TITLE
Update includes to work properly on ARM

### DIFF
--- a/src/dependancies/utility/fasttrigo.h
+++ b/src/dependancies/utility/fasttrigo.h
@@ -43,8 +43,18 @@
 #include <QtGui>
 #endif
 //#include <intrin.h>
+#if defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64) ||                                   \
+    (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
 #include <xmmintrin.h>
 #include <pmmintrin.h>
+#else
+#if defined(__arm__) || defined(__aarch64__) || defined(__riscv)
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include "simde/x86/sse2.h"
+#else
+#error Bark requires either X86/SSE2 or ARM architectures.
+#endif
+#endif
 
 //Default accuracy
 namespace FT {


### PR DESCRIPTION
Include simde on aarch64 rather than ximmintrin etc... directly Alternately you could just include the rack.hpp but this seems a bit lower level than that.

Closes #39